### PR TITLE
feat: 홈 화면 밴드 조회 api 구현

### DIFF
--- a/src/main/java/team3/kummit/config/DataInitializer.java
+++ b/src/main/java/team3/kummit/config/DataInitializer.java
@@ -89,7 +89,7 @@ public class DataInitializer {
                     .creatorName(member2.getName())
                     .emotion("슬픔")
                     .comment("우울한 날씨에 맞춰 슬픈 노래를 들어보세요")
-                    .endTime(LocalDateTime.now().plusDays(5))
+                    .endTime(LocalDateTime.now().plusDays(3))
                     .likeCount(3)
                     .peopleCount(2)
                     .songCount(1)
@@ -100,7 +100,7 @@ public class DataInitializer {
                     .creatorName(member1.getName())
                     .emotion("분노")
                     .comment("스트레스 받는 하루였지만 음악으로 해소해요")
-                    .endTime(LocalDateTime.now().plusDays(3))
+                    .endTime(LocalDateTime.now().plusDays(5))
                     .likeCount(2)
                     .peopleCount(1)
                     .songCount(0)
@@ -111,13 +111,24 @@ public class DataInitializer {
                     .creatorName(member3.getName())
                     .emotion("평온")
                     .comment("차분하고 평화로운 마음으로 음악을 감상해보세요")
-                    .endTime(LocalDateTime.now().plusDays(10))
+                    .endTime(LocalDateTime.now().plusDays(1))
                     .likeCount(8)
                     .peopleCount(4)
                     .songCount(3)
                     .build();
 
-            emotionBandRepository.saveAll(Arrays.asList(band1, band2, band3, band4));
+            EmotionBand band5 = EmotionBand.builder()
+                    .creator(member3)
+                    .creatorName(member3.getName())
+                    .emotion("즐거움")
+                    .comment("오늘은 너무 즐거운 해커톤 데이")
+                    .endTime(LocalDateTime.now().minusDays(1))
+                    .likeCount(999)
+                    .peopleCount(99)
+                    .songCount(10)
+                    .build();
+
+            emotionBandRepository.saveAll(Arrays.asList(band1, band2, band3, band4, band5));
 
             log.info("더미 데이터 초기화 완료!");
             log.info("생성된 멤버 수: {}", memberRepository.count());

--- a/src/main/java/team3/kummit/controller/EmotionBandController.java
+++ b/src/main/java/team3/kummit/controller/EmotionBandController.java
@@ -1,0 +1,37 @@
+package team3.kummit.controller;
+
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+import team3.kummit.dto.EmotionBandListResponse;
+import team3.kummit.service.EmotionBandService;
+
+@Tag(name = "EmotionBand", description = "감정밴드 관리")
+@RequestMapping("/api/emotion-bands")
+@RestController
+@RequiredArgsConstructor
+public class EmotionBandController {
+
+    private final EmotionBandService emotionBandService;
+
+    @Operation(summary = "감정밴드 목록 조회", description = "인기 밴드(좋아요 수 기준 상위 3개)와 전체 밴드(최신순 상위 10개)를 조회합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping
+    public ResponseEntity<EmotionBandListResponse> getEmotionBandLists(
+            @Parameter(description = "사용자 ID (선택사항)") @RequestParam(required = false) Long memberId) {
+        EmotionBandListResponse response = emotionBandService.getEmotionBandLists(memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/team3/kummit/dto/EmotionBandListResponse.java
+++ b/src/main/java/team3/kummit/dto/EmotionBandListResponse.java
@@ -1,0 +1,17 @@
+package team3.kummit.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionBandListResponse {
+    private List<EmotionBandResponse> popularBands; // 인기 밴드 (좋아요 수 기준 상위 3개)
+    private List<EmotionBandResponse> allBands;     // 전체 밴드 (최신순 상위 10개)
+}

--- a/src/main/java/team3/kummit/dto/EmotionBandResponse.java
+++ b/src/main/java/team3/kummit/dto/EmotionBandResponse.java
@@ -1,0 +1,39 @@
+package team3.kummit.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team3.kummit.domain.EmotionBand;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionBandResponse {
+    private Long id;
+    private String creatorName;
+    private String emotion;
+    private String comment;
+    private LocalDateTime endTime;
+    private Integer likeCount;
+    private Integer peopleCount;
+    private Integer songCount;
+    private boolean isLiked;
+
+    public static EmotionBandResponse from(EmotionBand emotionBand, boolean isLiked) {
+        return EmotionBandResponse.builder()
+                .id(emotionBand.getId())
+                .creatorName(emotionBand.getCreatorName())
+                .emotion(emotionBand.getEmotion())
+                .comment(emotionBand.getComment())
+                .endTime(emotionBand.getEndTime())
+                .likeCount(emotionBand.getLikeCount())
+                .peopleCount(emotionBand.getPeopleCount())
+                .songCount(emotionBand.getSongCount())
+                .isLiked(isLiked)
+                .build();
+    }
+}

--- a/src/main/java/team3/kummit/repository/EmotionBandRepository.java
+++ b/src/main/java/team3/kummit/repository/EmotionBandRepository.java
@@ -1,8 +1,21 @@
 package team3.kummit.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import team3.kummit.domain.EmotionBand;
 
 public interface EmotionBandRepository extends JpaRepository<EmotionBand, Long> {
+
+    // 현재 시간이 endTime을 지나지 않은 밴드들 중 좋아요 수 기준 상위 3개
+    @Query("SELECT e FROM EmotionBand e WHERE e.endTime > :currentTime ORDER BY e.likeCount DESC")
+    List<EmotionBand> findTop3ByLikeCountAndEndTimeAfter(@Param("currentTime") LocalDateTime currentTime);
+
+    // 현재 시간이 endTime을 지나지 않은 밴드들 중 endTime 기준 최신순 상위 10개
+    @Query("SELECT e FROM EmotionBand e WHERE e.endTime > :currentTime ORDER BY e.endTime DESC")
+    List<EmotionBand> findTop10ByEndTimeDescAndEndTimeAfter(@Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/team3/kummit/service/EmotionBandService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandService.java
@@ -1,0 +1,61 @@
+package team3.kummit.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team3.kummit.domain.EmotionBand;
+import team3.kummit.dto.EmotionBandListResponse;
+import team3.kummit.dto.EmotionBandResponse;
+import team3.kummit.exception.ResourceNotFoundException;
+import team3.kummit.repository.EmotionBandRepository;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionBandService {
+    private final EmotionBandRepository emotionBandRepository;
+    private final EmotionBandLikeService emotionBandLikeService;
+
+    @Transactional(readOnly = true)
+    public EmotionBandListResponse getEmotionBandLists(Long memberId) {
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        // 인기 밴드 조회 (좋아요 수 기준 상위 3개)
+        List<EmotionBand> popularBands = emotionBandRepository.findTop3ByLikeCountAndEndTimeAfter(currentTime);
+        List<EmotionBandResponse> popularBandResponses = popularBands.stream()
+                .limit(3) // 최대 3개만
+                .map(band -> {
+                    boolean isLiked = memberId != null && emotionBandLikeService.isLiked(band.getId(), memberId);
+                    return EmotionBandResponse.from(band, isLiked);
+                })
+                .collect(Collectors.toList());
+
+        // 전체 밴드 조회 (최신순 상위 10개)
+        List<EmotionBand> allBands = emotionBandRepository.findTop10ByEndTimeDescAndEndTimeAfter(currentTime);
+        List<EmotionBandResponse> allBandResponses = allBands.stream()
+                .limit(10) // 최대 10개만
+                .map(band -> {
+                    boolean isLiked = memberId != null && emotionBandLikeService.isLiked(band.getId(), memberId);
+                    return EmotionBandResponse.from(band, isLiked);
+                })
+                .collect(Collectors.toList());
+
+        return EmotionBandListResponse.builder()
+                .popularBands(popularBandResponses)
+                .allBands(allBandResponses)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public EmotionBandResponse getEmotionBand(Long emotionBandId, Long memberId) {
+        EmotionBand band = emotionBandRepository.findById(emotionBandId)
+                .orElseThrow(() -> new ResourceNotFoundException("감정밴드를 찾을 수 없습니다."));
+
+        boolean isLiked = memberId != null && emotionBandLikeService.isLiked(emotionBandId, memberId);
+        return EmotionBandResponse.from(band, isLiked);
+    }
+}


### PR DESCRIPTION
### Request
`GET /api/emotion-bands`

### Response
```
{
  "popularBands": [
    {
      "id": 4,
      "creatorName": "박민수",
      "emotion": "평온",
      "comment": "차분하고 평화로운 마음으로 음악을 감상해보세요",
      "endTime": "2024-01-15T10:00:00",
      "createdAt": "2024-01-10T10:00:00",
      "likeCount": 8,
      "peopleCount": 4,
      "songCount": 3,
      "isLiked": false
    }
    // ... 지금 인기있는 감정 밴드 -> 최대 3개
  ],
  "allBands": [
    // ... 전체 감정 밴드 -> 최신순으로 최대 10개
  ]
}
```

### TODO
- 음악 관련 구현이 끝나면 홈 화면 조회 api에서도 음악 목록을 리스트 형태로 내려주어야 한다
- 댓글 수 관련 필드 구현 필요