### PR TITLE
feat: 감정 밴드 아카이브 api 구현

### DIFF
--- a/src/main/java/team3/kummit/controller/EmotionBandArchiveController.java
+++ b/src/main/java/team3/kummit/controller/EmotionBandArchiveController.java
@@ -1,0 +1,39 @@
+package team3.kummit.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+import team3.kummit.dto.EmotionBandArchiveResponse;
+import team3.kummit.service.EmotionBandArchiveService;
+
+@Tag(name = "EmotionBand-Archive", description = "감정밴드 보관 관리")
+@RequestMapping("/api/emotion-bands")
+@RestController
+@RequiredArgsConstructor
+public class EmotionBandArchiveController {
+
+    private final EmotionBandArchiveService emotionBandArchiveService;
+
+    @Operation(summary = "보관 토글", description = "감정밴드를 보관하거나 보관 해제합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "감정밴드 또는 사용자를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/{emotionBandId}/archive")
+    public ResponseEntity<EmotionBandArchiveResponse> toggleArchive(
+            @Parameter(description = "감정밴드 ID") @PathVariable Long emotionBandId,
+            @Parameter(description = "사용자 ID") @RequestParam Long memberId) {
+        EmotionBandArchiveResponse response = emotionBandArchiveService.toggleArchive(emotionBandId, memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/team3/kummit/controller/EmotionBandController.java
+++ b/src/main/java/team3/kummit/controller/EmotionBandController.java
@@ -44,8 +44,9 @@ public class EmotionBandController {
     })
     @GetMapping("/{emotionBandId}/detail")
     public ResponseEntity<EmotionBandDetailResponse> getEmotionBandDetail(
-            @Parameter(description = "감정밴드 ID") @PathVariable Long emotionBandId) {
-        EmotionBandDetailResponse response = emotionBandService.getEmotionBandDetail(emotionBandId);
+            @Parameter(description = "감정밴드 ID") @PathVariable Long emotionBandId,
+            @Parameter(description = "사용자 ID") @RequestParam Long memberId) {
+        EmotionBandDetailResponse response = emotionBandService.getEmotionBandDetail(emotionBandId, memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/team3/kummit/domain/EmotionBandArchive.java
+++ b/src/main/java/team3/kummit/domain/EmotionBandArchive.java
@@ -1,5 +1,9 @@
 package team3.kummit.domain;
 
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,4 +25,7 @@ public class EmotionBandArchive {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="emotion_band_id")
     private EmotionBand emotionBand;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/team3/kummit/dto/EmotionBandArchiveResponse.java
+++ b/src/main/java/team3/kummit/dto/EmotionBandArchiveResponse.java
@@ -1,0 +1,17 @@
+package team3.kummit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionBandArchiveResponse {
+    private boolean archived;
+    private String message;
+
+    public static EmotionBandArchiveResponse of(boolean archived, String message) {
+        return new EmotionBandArchiveResponse(archived, message);
+    }
+}

--- a/src/main/java/team3/kummit/dto/EmotionBandDetailResponse.java
+++ b/src/main/java/team3/kummit/dto/EmotionBandDetailResponse.java
@@ -25,8 +25,9 @@ public class EmotionBandDetailResponse {
     private Integer commentCount;
     private List<SongResponse> songs;
     private List<CommentResponse> comments;
+    private boolean isArchived;
 
-    public static EmotionBandDetailResponse from(EmotionBand emotionBand, List<SongResponse> songs, List<CommentResponse> comments) {
+    public static EmotionBandDetailResponse from(EmotionBand emotionBand, List<SongResponse> songs, List<CommentResponse> comments, boolean isArchived) {
         return EmotionBandDetailResponse.builder()
                 .id(emotionBand.getId())
                 .creatorName(emotionBand.getCreatorName())
@@ -39,6 +40,7 @@ public class EmotionBandDetailResponse {
                 .commentCount(emotionBand.getCommentCount())
                 .songs(songs)
                 .comments(comments)
+                .isArchived(isArchived)
                 .build();
     }
 }

--- a/src/main/java/team3/kummit/repository/EmotionBandArchiveRepository.java
+++ b/src/main/java/team3/kummit/repository/EmotionBandArchiveRepository.java
@@ -1,0 +1,12 @@
+package team3.kummit.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team3.kummit.domain.EmotionBandArchive;
+
+public interface EmotionBandArchiveRepository extends JpaRepository<EmotionBandArchive, Long> {
+    Optional<EmotionBandArchive> findByCreatorIdAndEmotionBandId(Long memberId, Long emotionBandId);
+    boolean existsByCreatorIdAndEmotionBandId(Long memberId, Long emotionBandId);
+}

--- a/src/main/java/team3/kummit/service/EmotionBandArchiveService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandArchiveService.java
@@ -1,0 +1,56 @@
+package team3.kummit.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team3.kummit.domain.EmotionBand;
+import team3.kummit.domain.EmotionBandArchive;
+import team3.kummit.domain.Member;
+import team3.kummit.dto.EmotionBandArchiveResponse;
+import team3.kummit.exception.ResourceNotFoundException;
+import team3.kummit.repository.EmotionBandArchiveRepository;
+import team3.kummit.repository.EmotionBandRepository;
+import team3.kummit.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionBandArchiveService {
+    private final EmotionBandArchiveRepository archiveRepository;
+    private final EmotionBandRepository emotionBandRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public EmotionBandArchiveResponse toggleArchive(Long emotionBandId, Long memberId) {
+        // emotionBandId 검증
+        EmotionBand emotionBand = emotionBandRepository.findById(emotionBandId)
+                .orElseThrow(() -> new ResourceNotFoundException("감정밴드를 찾을 수 없습니다."));
+
+        // memberId 검증
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 보관 상태값
+        boolean isArchived = archiveRepository.existsByCreatorIdAndEmotionBandId(memberId, emotionBandId);
+
+        if (isArchived) {
+            // 보관 해제 toggle
+            archiveRepository.findByCreatorIdAndEmotionBandId(memberId, emotionBandId)
+                    .ifPresent(archiveRepository::delete);
+            return EmotionBandArchiveResponse.of(false, "보관이 해제되었습니다.");
+        } else {
+            // 보관 추가 toggle
+            EmotionBandArchive archive = EmotionBandArchive.builder()
+                    .creator(member)
+                    .emotionBand(emotionBand)
+                    .build();
+            archiveRepository.save(archive);
+            return EmotionBandArchiveResponse.of(true, "보관되었습니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isArchived(Long emotionBandId, Long memberId) {
+        return archiveRepository.existsByCreatorIdAndEmotionBandId(memberId, emotionBandId);
+    }
+}

--- a/src/main/java/team3/kummit/service/EmotionBandService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandService.java
@@ -23,6 +23,7 @@ import team3.kummit.repository.SongRepository;
 public class EmotionBandService {
     private final EmotionBandRepository emotionBandRepository;
     private final EmotionBandLikeService emotionBandLikeService;
+    private final EmotionBandArchiveService emotionBandArchiveService;
     private final CommentService commentService;
     private final SongRepository songRepository;
 
@@ -66,7 +67,7 @@ public class EmotionBandService {
     }
 
     @Transactional(readOnly = true)
-    public EmotionBandDetailResponse getEmotionBandDetail(Long emotionBandId) {
+    public EmotionBandDetailResponse getEmotionBandDetail(Long emotionBandId, Long memberId) {
         // 감정밴드 조회
         EmotionBand emotionBand = emotionBandRepository.findById(emotionBandId)
                 .orElseThrow(() -> new ResourceNotFoundException("감정밴드를 찾을 수 없습니다."));
@@ -80,6 +81,9 @@ public class EmotionBandService {
         // 댓글 목록 조회
         List<CommentResponse> comments = commentService.getComments(emotionBandId);
 
-        return EmotionBandDetailResponse.from(emotionBand, songs, comments);
+        // 보관 여부 확인
+        boolean isArchived = memberId != null && emotionBandArchiveService.isArchived(emotionBandId, memberId);
+
+        return EmotionBandDetailResponse.from(emotionBand, songs, comments, isArchived);
     }
 }

--- a/src/test/java/team3/kummit/service/EmotionBandArchiveServiceTest.java
+++ b/src/test/java/team3/kummit/service/EmotionBandArchiveServiceTest.java
@@ -1,0 +1,195 @@
+package team3.kummit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team3.kummit.domain.EmotionBand;
+import team3.kummit.domain.EmotionBandArchive;
+import team3.kummit.domain.Member;
+import team3.kummit.dto.EmotionBandArchiveResponse;
+import team3.kummit.exception.ResourceNotFoundException;
+import team3.kummit.repository.EmotionBandArchiveRepository;
+import team3.kummit.repository.EmotionBandRepository;
+import team3.kummit.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class EmotionBandArchiveServiceTest {
+
+    @Mock
+    private EmotionBandArchiveRepository archiveRepository;
+
+    @Mock
+    private EmotionBandRepository emotionBandRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private EmotionBandArchiveService emotionBandArchiveService;
+
+    private Member testMember;
+    private EmotionBand testEmotionBand;
+    private EmotionBandArchive testArchive;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.builder()
+                .id(1L)
+                .name("테스트유저")
+                .email("test@test.com")
+                .build();
+
+        testEmotionBand = EmotionBand.builder()
+                .id(1L)
+                .creator(testMember)
+                .creatorName("테스트유저")
+                .emotion("기쁨")
+                .description("테스트 감정밴드")
+                .endTime(LocalDateTime.now().plusDays(1))
+                .likeCount(0)
+                .peopleCount(0)
+                .songCount(0)
+                .commentCount(0)
+                .build();
+
+        testArchive = EmotionBandArchive.builder()
+                .id(1L)
+                .creator(testMember)
+                .emotionBand(testEmotionBand)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("보관 추가 성공")
+    void toggleArchive_AddArchive_Success() {
+        // given
+        Long emotionBandId = 1L;
+        Long memberId = 1L;
+
+        when(emotionBandRepository.findById(emotionBandId))
+                .thenReturn(java.util.Optional.of(testEmotionBand));
+        when(memberRepository.findById(memberId))
+                .thenReturn(java.util.Optional.of(testMember));
+        when(archiveRepository.existsByCreatorIdAndEmotionBandId(memberId, emotionBandId))
+                .thenReturn(false);
+        when(archiveRepository.save(any(EmotionBandArchive.class)))
+                .thenReturn(testArchive);
+
+        // when
+        EmotionBandArchiveResponse result = emotionBandArchiveService.toggleArchive(emotionBandId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isArchived()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("보관되었습니다.");
+        verify(archiveRepository).save(any(EmotionBandArchive.class));
+    }
+
+    @Test
+    @DisplayName("보관 해제 성공")
+    void toggleArchive_RemoveArchive_Success() {
+        // given
+        Long emotionBandId = 1L;
+        Long memberId = 1L;
+
+        when(emotionBandRepository.findById(emotionBandId))
+                .thenReturn(java.util.Optional.of(testEmotionBand));
+        when(memberRepository.findById(memberId))
+                .thenReturn(java.util.Optional.of(testMember));
+        when(archiveRepository.existsByCreatorIdAndEmotionBandId(memberId, emotionBandId))
+                .thenReturn(true);
+        when(archiveRepository.findByCreatorIdAndEmotionBandId(memberId, emotionBandId))
+                .thenReturn(java.util.Optional.of(testArchive));
+
+        // when
+        EmotionBandArchiveResponse result = emotionBandArchiveService.toggleArchive(emotionBandId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isArchived()).isFalse();
+        assertThat(result.getMessage()).isEqualTo("보관이 해제되었습니다.");
+        verify(archiveRepository).delete(testArchive);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 감정밴드 보관 시 예외 발생")
+    void toggleArchive_EmotionBandNotFound_ThrowsException() {
+        // given
+        Long emotionBandId = 999L;
+        Long memberId = 1L;
+
+        when(emotionBandRepository.findById(emotionBandId))
+                .thenReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> emotionBandArchiveService.toggleArchive(emotionBandId, memberId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("감정밴드를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 보관 시 예외 발생")
+    void toggleArchive_MemberNotFound_ThrowsException() {
+        // given
+        Long emotionBandId = 1L;
+        Long memberId = 999L;
+
+        when(emotionBandRepository.findById(emotionBandId))
+                .thenReturn(java.util.Optional.of(testEmotionBand));
+        when(memberRepository.findById(memberId))
+                .thenReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> emotionBandArchiveService.toggleArchive(emotionBandId, memberId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("보관 여부 확인 - 보관된 경우")
+    void isArchived_WhenArchived_ReturnsTrue() {
+        // given
+        Long emotionBandId = 1L;
+        Long memberId = 1L;
+
+        when(archiveRepository.existsByCreatorIdAndEmotionBandId(memberId, emotionBandId))
+                .thenReturn(true);
+
+        // when
+        boolean result = emotionBandArchiveService.isArchived(emotionBandId, memberId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("보관 여부 확인 - 보관되지 않은 경우")
+    void isArchived_WhenNotArchived_ReturnsFalse() {
+        // given
+        Long emotionBandId = 1L;
+        Long memberId = 1L;
+
+        when(archiveRepository.existsByCreatorIdAndEmotionBandId(memberId, emotionBandId))
+                .thenReturn(false);
+
+        // when
+        boolean result = emotionBandArchiveService.isArchived(emotionBandId, memberId);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
- 감정 밴드 상세 페이지에 접속할 때, 보관 여부 상태를 표시하도록 EmotionBandDetailResponse도 수정
  - 상태 조회를 위한 사용자 아이디도 쿼리 파라미터로 받아와야 함

### Request

`POST /api/emotion-bands/{emotionBandId}/archive?memberId=1`

### Response

```json
{
  "archived": true,
  "message": "보관되었습니다."
}
```

```
{
  "archived": false,
  "message": "보관이 해제되었습니다."
}
```