### PR TITLE
feat: 감정 밴드 아카이브

### DIFF
--- a/src/main/java/team3/kummit/controller/EmotionBandController.java
+++ b/src/main/java/team3/kummit/controller/EmotionBandController.java
@@ -1,6 +1,7 @@
 package team3.kummit.controller;
 
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,9 +13,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
+import team3.kummit.domain.Member;
+import team3.kummit.dto.EmotionBandCreateRequest;
 import team3.kummit.dto.EmotionBandDetailResponse;
 import team3.kummit.dto.EmotionBandListResponse;
 import team3.kummit.service.EmotionBandService;
+import team3.kummit.service.MemberService;
 
 @Tag(name = "EmotionBand", description = "감정밴드 관리")
 @RequestMapping("/api/emotion-bands")
@@ -23,6 +27,26 @@ import team3.kummit.service.EmotionBandService;
 public class EmotionBandController {
 
     private final EmotionBandService emotionBandService;
+    private final MemberService memberService;
+
+    @PostMapping()
+    @Operation(
+        summary = "새 감정밴드 생성",
+        description = "새로운 감정밴드를 생성합니다. 사용자 ID는 선택사항입니다.",
+        tags = {"EmotionBand"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "감정밴드 생성 성공", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<Long> createEmotionBand(
+            @Parameter(description = "사용자 ID (선택사항)") @RequestParam(required = false) Long memberId,
+            @RequestBody EmotionBandCreateRequest emotionBandCreateRequest) {
+        Member member = memberService.findById(memberId);
+        Long emotionBandId = emotionBandService.createEmotionBand(member, emotionBandCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(emotionBandId);
+    }
 
     @Operation(summary = "감정밴드 목록 조회", description = "인기 밴드(좋아요 수 기준 상위 3개)와 전체 밴드(최신순 상위 10개)를 조회합니다")
     @ApiResponses(value = {

--- a/src/main/java/team3/kummit/dto/EmotionBandCreateRequest.java
+++ b/src/main/java/team3/kummit/dto/EmotionBandCreateRequest.java
@@ -1,0 +1,4 @@
+package team3.kummit.dto;
+
+public class EmotionBandCreateRequest {
+}

--- a/src/main/java/team3/kummit/dto/EmotionBandCreateRequest.java
+++ b/src/main/java/team3/kummit/dto/EmotionBandCreateRequest.java
@@ -1,4 +1,22 @@
 package team3.kummit.dto;
 
+
+import lombok.Data;
+
+@Data
 public class EmotionBandCreateRequest {
+
+    private String emotion;
+    private String description;
+    private SongDto song;
+
+    @Data
+    public static class SongDto{
+        private String title;
+        private String artist;
+        private String albumImageLink;
+        private String previewLink;
+    }
+
+
 }

--- a/src/main/java/team3/kummit/service/EmotionBandService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandService.java
@@ -9,11 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team3.kummit.domain.EmotionBand;
-import team3.kummit.dto.CommentResponse;
-import team3.kummit.dto.EmotionBandDetailResponse;
-import team3.kummit.dto.EmotionBandListResponse;
-import team3.kummit.dto.EmotionBandResponse;
-import team3.kummit.dto.SongResponse;
+import team3.kummit.domain.Member;
+import team3.kummit.domain.Song;
+import team3.kummit.dto.*;
 import team3.kummit.exception.ResourceNotFoundException;
 import team3.kummit.repository.EmotionBandRepository;
 import team3.kummit.repository.SongRepository;
@@ -25,6 +23,31 @@ public class EmotionBandService {
     private final EmotionBandLikeService emotionBandLikeService;
     private final CommentService commentService;
     private final SongRepository songRepository;
+
+    @Transactional
+    public Long createEmotionBand(Member member, EmotionBandCreateRequest emotionBandCreateRequest) {
+        EmotionBand emotionBand = emotionBandRepository.save(EmotionBand.builder()
+                .creator(member)
+                .creatorName(member.getName())
+                .emotion(emotionBandCreateRequest.getEmotion())
+                .description(emotionBandCreateRequest.getDescription())
+                .endTime(LocalDateTime.now().plusDays(1))
+                .likeCount(0)
+                .peopleCount(0)
+                .songCount(1)
+                .commentCount(0).build());
+        Song song = songRepository.save(Song.builder()
+                .creator(member)
+                .emotionBand(emotionBand)
+                .creatorName(member.getName())
+                .title(emotionBandCreateRequest.getSong().getTitle())
+                .artist(emotionBandCreateRequest.getSong().getArtist())
+                .albumImageLink(emotionBandCreateRequest.getSong().getAlbumImageLink())
+                .previewLink(emotionBandCreateRequest.getSong().getPreviewLink())
+                .createdAt(LocalDateTime.now())
+                .build());
+        return emotionBand.getId();
+    }
 
     @Transactional(readOnly = true)
     public EmotionBandListResponse getEmotionBandLists(Long memberId) {

--- a/src/main/java/team3/kummit/service/MemberService.java
+++ b/src/main/java/team3/kummit/service/MemberService.java
@@ -1,0 +1,4 @@
+package team3.kummit.service;
+
+public class MemberService {
+}

--- a/src/main/java/team3/kummit/service/MemberService.java
+++ b/src/main/java/team3/kummit/service/MemberService.java
@@ -1,4 +1,19 @@
 package team3.kummit.service;
 
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import team3.kummit.domain.Member;
+import team3.kummit.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long memberId){
+        return memberRepository.findById(memberId).orElseThrow(()-> new IllegalArgumentException("Not existing Member id"));
+    }
+
 }

--- a/src/test/java/team3/kummit/service/EmotionBandServiceTest.java
+++ b/src/test/java/team3/kummit/service/EmotionBandServiceTest.java
@@ -1,51 +1,32 @@
 package team3.kummit.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
 import team3.kummit.domain.EmotionBand;
 import team3.kummit.domain.Member;
 import team3.kummit.domain.Song;
 import team3.kummit.dto.EmotionBandCreateRequest;
-import team3.kummit.repository.EmotionBandRepository;
-import team3.kummit.repository.SongRepository;
-
-import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import team3.kummit.repository.MemberRepository;
 
 @SpringBootTest
 @Transactional
 class EmotionBandServiceTest {
 
-    @Mock
-    private EmotionBandRepository emotionBandRepository;
+    @Autowired
+    EmotionBandService emotionBandService;
 
-    @Mock
-    private SongRepository songRepository;
+    @Autowired
+    MemberRepository memberRepository;
 
-    @Mock
-    private EmotionBandLikeService emotionBandLikeService;
-
-    @Mock
-    private CommentService commentService;
-
-    @InjectMocks
-    private EmotionBandService emotionBandService;
-
-    public EmotionBandServiceTest() {
-        MockitoAnnotations.openMocks(this);
-    }
-
-    /**
-     * Tests the createEmotionBand method by simulating valid input.
-     * Ensures that the EmotionBand and Song entities are successfully persisted
-     * and that a valid ID is returned.
-     */
     @Test
     void testCreateEmotionBand_Success() {
         // Arrange
@@ -84,34 +65,13 @@ class EmotionBandServiceTest {
                 .createdAt(LocalDateTime.now())
                 .emotionBand(savedEmotionBand)
                 .build();
-
-        when(emotionBandRepository.save(any(EmotionBand.class))).thenReturn(savedEmotionBand);
-        when(songRepository.save(any(Song.class))).thenReturn(savedSong);
-
         // Act
+        memberRepository.save(creator);
         Long resultId = emotionBandService.createEmotionBand(creator, request);
 
         // Assert
         assertNotNull(resultId);
         assertEquals(1L, resultId);
-        verify(emotionBandRepository, times(1)).save(any(EmotionBand.class));
-        verify(songRepository, times(1)).save(any(Song.class));
     }
 
-    /**
-     * Tests the createEmotionBand method with invalid inputs.
-     * Verifies that the method throws a NullPointerException when input data is incomplete.
-     */
-    @Test
-    void testCreateEmotionBand_InvalidInput() {
-        // Arrange
-        Member creator = Member.builder().id(1L).build();
-        EmotionBandCreateRequest invalidRequest = new EmotionBandCreateRequest();
-
-        // Act & Assert
-        assertThrows(NullPointerException.class,
-                () -> emotionBandService.createEmotionBand(creator, invalidRequest));
-        verify(emotionBandRepository, never()).save(any(EmotionBand.class));
-        verify(songRepository, never()).save(any(Song.class));
-    }
 }

--- a/src/test/java/team3/kummit/service/EmotionBandServiceTest.java
+++ b/src/test/java/team3/kummit/service/EmotionBandServiceTest.java
@@ -1,0 +1,117 @@
+package team3.kummit.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import team3.kummit.domain.EmotionBand;
+import team3.kummit.domain.Member;
+import team3.kummit.domain.Song;
+import team3.kummit.dto.EmotionBandCreateRequest;
+import team3.kummit.repository.EmotionBandRepository;
+import team3.kummit.repository.SongRepository;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Transactional
+class EmotionBandServiceTest {
+
+    @Mock
+    private EmotionBandRepository emotionBandRepository;
+
+    @Mock
+    private SongRepository songRepository;
+
+    @Mock
+    private EmotionBandLikeService emotionBandLikeService;
+
+    @Mock
+    private CommentService commentService;
+
+    @InjectMocks
+    private EmotionBandService emotionBandService;
+
+    public EmotionBandServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * Tests the createEmotionBand method by simulating valid input.
+     * Ensures that the EmotionBand and Song entities are successfully persisted
+     * and that a valid ID is returned.
+     */
+    @Test
+    void testCreateEmotionBand_Success() {
+        // Arrange
+        Member creator = Member.builder().id(1L).build();
+        EmotionBandCreateRequest.SongDto songDto = new EmotionBandCreateRequest.SongDto();
+        songDto.setTitle("Test Song");
+        songDto.setArtist("Test Artist");
+        songDto.setAlbumImageLink("https://test.com/image.jpg");
+        songDto.setPreviewLink("https://test.com/preview.mp3");
+
+        EmotionBandCreateRequest request = new EmotionBandCreateRequest();
+        request.setEmotion("Happiness");
+        request.setDescription("Test Description");
+        request.setSong(songDto);
+
+        EmotionBand savedEmotionBand = EmotionBand.builder()
+                .id(1L)
+                .creator(creator)
+                .emotion("Happiness")
+                .description("Test Description")
+                .creatorName("Test Creator")
+                .endTime(LocalDateTime.now().plusDays(1))
+                .likeCount(0)
+                .peopleCount(0)
+                .songCount(1)
+                .commentCount(0)
+                .build();
+
+        Song savedSong = Song.builder()
+                .id(1L)
+                .creator(creator)
+                .title("Test Song")
+                .artist("Test Artist")
+                .albumImageLink("https://test.com/image.jpg")
+                .previewLink("https://test.com/preview.mp3")
+                .createdAt(LocalDateTime.now())
+                .emotionBand(savedEmotionBand)
+                .build();
+
+        when(emotionBandRepository.save(any(EmotionBand.class))).thenReturn(savedEmotionBand);
+        when(songRepository.save(any(Song.class))).thenReturn(savedSong);
+
+        // Act
+        Long resultId = emotionBandService.createEmotionBand(creator, request);
+
+        // Assert
+        assertNotNull(resultId);
+        assertEquals(1L, resultId);
+        verify(emotionBandRepository, times(1)).save(any(EmotionBand.class));
+        verify(songRepository, times(1)).save(any(Song.class));
+    }
+
+    /**
+     * Tests the createEmotionBand method with invalid inputs.
+     * Verifies that the method throws a NullPointerException when input data is incomplete.
+     */
+    @Test
+    void testCreateEmotionBand_InvalidInput() {
+        // Arrange
+        Member creator = Member.builder().id(1L).build();
+        EmotionBandCreateRequest invalidRequest = new EmotionBandCreateRequest();
+
+        // Act & Assert
+        assertThrows(NullPointerException.class,
+                () -> emotionBandService.createEmotionBand(creator, invalidRequest));
+        verify(emotionBandRepository, never()).save(any(EmotionBand.class));
+        verify(songRepository, never()).save(any(Song.class));
+    }
+}


### PR DESCRIPTION
- 감정 밴드 상세 페이지에 접속할 때, 보관 여부 상태를 표시하도록 EmotionBandDetailResponse도 수정
  - 상태 조회를 위한 사용자 아이디도 쿼리 파라미터로 받아와야 함

### Request

`POST /api/emotion-bands?memberId=1`

### Response

```
{
  "emotionBandId": 1
}
```