### PR TITLE
fix - 연관 데이터를 함께 변경하지 않는 문제

### DIFF
--- a/src/main/java/team3/kummit/domain/Member.java
+++ b/src/main/java/team3/kummit/domain/Member.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 public class Member {
 

--- a/src/main/java/team3/kummit/service/EmotionBandArchiveService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandArchiveService.java
@@ -37,6 +37,21 @@ public class EmotionBandArchiveService {
             // 보관 해제 toggle
             archiveRepository.findByCreatorIdAndEmotionBandId(memberId, emotionBandId)
                     .ifPresent(archiveRepository::delete);
+
+            // peopleCount 감소, bandJoinCount 감소
+            Integer currentPeopleCount = emotionBand.getPeopleCount() != null ? emotionBand.getPeopleCount() : 0;
+            Integer currentBandJoinCount = member.getBandJoinCount() != null ? member.getBandJoinCount() : 0;
+
+            EmotionBand updatedEmotionBand = emotionBand.toBuilder()
+                    .peopleCount(Math.max(0, currentPeopleCount - 1))
+                    .build();
+            Member updatedMember = member.toBuilder()
+                    .bandJoinCount(Math.max(0, currentBandJoinCount - 1))
+                    .build();
+
+            emotionBandRepository.save(updatedEmotionBand);
+            memberRepository.save(updatedMember);
+
             return EmotionBandArchiveResponse.of(false, "보관이 해제되었습니다.");
         } else {
             // 보관 추가 toggle
@@ -45,6 +60,21 @@ public class EmotionBandArchiveService {
                     .emotionBand(emotionBand)
                     .build();
             archiveRepository.save(archive);
+
+            // peopleCount 증가, bandJoinCount 증가
+            Integer currentPeopleCount = emotionBand.getPeopleCount() != null ? emotionBand.getPeopleCount() : 0;
+            Integer currentBandJoinCount = member.getBandJoinCount() != null ? member.getBandJoinCount() : 0;
+
+            EmotionBand updatedEmotionBand = emotionBand.toBuilder()
+                    .peopleCount(currentPeopleCount + 1)
+                    .build();
+            Member updatedMember = member.toBuilder()
+                    .bandJoinCount(currentBandJoinCount + 1)
+                    .build();
+
+            emotionBandRepository.save(updatedEmotionBand);
+            memberRepository.save(updatedMember);
+
             return EmotionBandArchiveResponse.of(true, "보관되었습니다.");
         }
     }

--- a/src/main/java/team3/kummit/service/EmotionBandLikeService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandLikeService.java
@@ -27,19 +27,31 @@ public class EmotionBandLikeService {
         return likeRepository.findByCreatorIdAndEmotionBandId(memberId, emotionBandId)
                 .map(like -> {
                     likeRepository.delete(like);
-                    EmotionBand updatedBand = EmotionBand.builder()
+
+                    // likeCount 감소
+                    Integer currentBandLikeCount = band.getLikeCount() != null ? band.getLikeCount() : 0;
+                    Integer currentMemberLikeCount = member.getLikeCount() != null ? member.getLikeCount() : 0;
+
+                    EmotionBand updatedBand = band.toBuilder()
                             .id(band.getId())
                             .creator(band.getCreator())
                             .creatorName(band.getCreatorName())
                             .emotion(band.getEmotion())
                             .description(band.getDescription())
                             .endTime(band.getEndTime())
-                            .likeCount(band.getLikeCount() - 1)
+                            .likeCount(Math.max(0, currentBandLikeCount - 1))
                             .peopleCount(band.getPeopleCount())
                             .songCount(band.getSongCount())
                             .commentCount(band.getCommentCount())
                             .build();
+
+                    Member updatedMember = member.toBuilder()
+                            .likeCount(Math.max(0, currentMemberLikeCount - 1))
+                            .build();
+
                     bandRepository.save(updatedBand);
+                    memberRepository.save(updatedMember);
+
                     return false;
                 })
                 .orElseGet(() -> {
@@ -47,19 +59,31 @@ public class EmotionBandLikeService {
                             .creator(member)
                             .emotionBand(band)
                             .build());
-                    EmotionBand updatedBand = EmotionBand.builder()
+
+                    // likeCount 증가
+                    Integer currentBandLikeCount = band.getLikeCount() != null ? band.getLikeCount() : 0;
+                    Integer currentMemberLikeCount = member.getLikeCount() != null ? member.getLikeCount() : 0;
+
+                    EmotionBand updatedBand = band.toBuilder()
                             .id(band.getId())
                             .creator(band.getCreator())
                             .creatorName(band.getCreatorName())
                             .emotion(band.getEmotion())
                             .description(band.getDescription())
                             .endTime(band.getEndTime())
-                            .likeCount(band.getLikeCount() + 1)
+                            .likeCount(currentBandLikeCount + 1)
                             .peopleCount(band.getPeopleCount())
                             .songCount(band.getSongCount())
                             .commentCount(band.getCommentCount())
                             .build();
+
+                    Member updatedMember = member.toBuilder()
+                            .likeCount(currentMemberLikeCount + 1)
+                            .build();
+
                     bandRepository.save(updatedBand);
+                    memberRepository.save(updatedMember);
+
                     return true;
                 });
     }

--- a/src/main/java/team3/kummit/service/SongService.java
+++ b/src/main/java/team3/kummit/service/SongService.java
@@ -57,6 +57,13 @@ public class SongService {
                 .build();
         emotionBandRepository.save(updatedEmotionBand);
 
+        // 사용자의 음악 추가 수 증가
+        Integer currentSongAddCount = member.getSongAddCount() != null ? member.getSongAddCount() : 0;
+        Member updatedMember = member.toBuilder()
+                .songAddCount(currentSongAddCount + 1)
+                .build();
+        memberRepository.save(updatedMember);
+
         return SongResponse.from(savedSong);
     }
 }

--- a/src/test/java/team3/kummit/service/EmotionBandArchiveServiceTest.java
+++ b/src/test/java/team3/kummit/service/EmotionBandArchiveServiceTest.java
@@ -88,6 +88,10 @@ class EmotionBandArchiveServiceTest {
                 .thenReturn(false);
         when(archiveRepository.save(any(EmotionBandArchive.class)))
                 .thenReturn(testArchive);
+        when(emotionBandRepository.save(any(EmotionBand.class)))
+                .thenReturn(testEmotionBand.toBuilder().peopleCount(1).build());
+        when(memberRepository.save(any(Member.class)))
+                .thenReturn(testMember.toBuilder().bandJoinCount(1).build());
 
         // when
         EmotionBandArchiveResponse result = emotionBandArchiveService.toggleArchive(emotionBandId, memberId);
@@ -97,6 +101,8 @@ class EmotionBandArchiveServiceTest {
         assertThat(result.isArchived()).isTrue();
         assertThat(result.getMessage()).isEqualTo("보관되었습니다.");
         verify(archiveRepository).save(any(EmotionBandArchive.class));
+        verify(emotionBandRepository).save(any(EmotionBand.class));
+        verify(memberRepository).save(any(Member.class));
     }
 
     @Test
@@ -114,6 +120,10 @@ class EmotionBandArchiveServiceTest {
                 .thenReturn(true);
         when(archiveRepository.findByCreatorIdAndEmotionBandId(memberId, emotionBandId))
                 .thenReturn(java.util.Optional.of(testArchive));
+        when(emotionBandRepository.save(any(EmotionBand.class)))
+                .thenReturn(testEmotionBand.toBuilder().peopleCount(0).build());
+        when(memberRepository.save(any(Member.class)))
+                .thenReturn(testMember.toBuilder().bandJoinCount(0).build());
 
         // when
         EmotionBandArchiveResponse result = emotionBandArchiveService.toggleArchive(emotionBandId, memberId);
@@ -123,6 +133,8 @@ class EmotionBandArchiveServiceTest {
         assertThat(result.isArchived()).isFalse();
         assertThat(result.getMessage()).isEqualTo("보관이 해제되었습니다.");
         verify(archiveRepository).delete(testArchive);
+        verify(emotionBandRepository).save(any(EmotionBand.class));
+        verify(memberRepository).save(any(Member.class));
     }
 
     @Test

--- a/src/test/java/team3/kummit/service/EmotionBandLikeServiceTest.java
+++ b/src/test/java/team3/kummit/service/EmotionBandLikeServiceTest.java
@@ -88,12 +88,15 @@ class EmotionBandLikeServiceTest {
                 .thenReturn(testLike);
         when(bandRepository.save(any(EmotionBand.class)))
                 .thenReturn(testEmotionBand.toBuilder().likeCount(6).build());
+        when(memberRepository.save(any(Member.class)))
+                .thenReturn(testMember.toBuilder().likeCount(11).build());
 
         boolean result = emotionBandLikeService.toggleLike(emotionBandId, memberId);
 
         assertThat(result).isTrue();
         verify(likeRepository).save(any(EmotionBandLike.class));
         verify(bandRepository).save(any(EmotionBand.class));
+        verify(memberRepository).save(any(Member.class));
     }
 
     @Test
@@ -110,12 +113,15 @@ class EmotionBandLikeServiceTest {
                 .thenReturn(Optional.of(testLike));
         when(bandRepository.save(any(EmotionBand.class)))
                 .thenReturn(testEmotionBand.toBuilder().likeCount(4).build());
+        when(memberRepository.save(any(Member.class)))
+                .thenReturn(testMember.toBuilder().likeCount(9).build());
 
         boolean result = emotionBandLikeService.toggleLike(emotionBandId, memberId);
 
         assertThat(result).isFalse();
         verify(likeRepository).delete(testLike);
         verify(bandRepository).save(any(EmotionBand.class));
+        verify(memberRepository).save(any(Member.class));
     }
 
     @Test

--- a/src/test/java/team3/kummit/service/SongServiceTest.java
+++ b/src/test/java/team3/kummit/service/SongServiceTest.java
@@ -101,6 +101,8 @@ class SongServiceTest {
                 .thenReturn(savedSong);
         when(emotionBandRepository.save(any(EmotionBand.class)))
                 .thenReturn(testEmotionBand.toBuilder().songCount(1).build());
+        when(memberRepository.save(any(Member.class)))
+                .thenReturn(testMember.toBuilder().songAddCount(1).build());
 
         SongResponse result = songService.addSong(emotionBandId, memberId, testSongRequest);
 
@@ -112,6 +114,7 @@ class SongServiceTest {
         assertThat(result.getEmotion()).isEqualTo("기쁨");
 
         verify(emotionBandRepository).save(any(EmotionBand.class));
+        verify(memberRepository).save(any(Member.class));
     }
 
     @Test


### PR DESCRIPTION
- toggleArchive를 수행할 때, EmotionBand의 peopleCount와 Member의 bandJoinCount를 업데이트
- toggleLike를 수행할 때, EmotionBand의 likeCount와 Member의 likeCount를 업데이트
- addSong을 수행할 때, Member의 songAddCount를 업데이트