### PR TITLE
edit: 메인 페이지 진입 시 음악 목록도 가져오도록 수정

### DIFF
--- a/src/main/java/team3/kummit/controller/EmotionBandController.java
+++ b/src/main/java/team3/kummit/controller/EmotionBandController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
-import team3.kummit.domain.Member;
 import team3.kummit.dto.EmotionBandCreateRequest;
 import team3.kummit.dto.EmotionBandCreateResponse;
 import team3.kummit.dto.EmotionBandDetailResponse;

--- a/src/main/java/team3/kummit/dto/EmotionBandResponse.java
+++ b/src/main/java/team3/kummit/dto/EmotionBandResponse.java
@@ -1,6 +1,7 @@
 package team3.kummit.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,8 +24,9 @@ public class EmotionBandResponse {
     private Integer songCount;
     private Integer commentCount;
     private boolean isLiked;
+    private List<SongResponse> songs;
 
-    public static EmotionBandResponse from(EmotionBand emotionBand, boolean isLiked) {
+    public static EmotionBandResponse from(EmotionBand emotionBand, boolean isLiked, List<SongResponse> songs) {
         return EmotionBandResponse.builder()
                 .id(emotionBand.getId())
                 .creatorName(emotionBand.getCreatorName())
@@ -36,6 +38,7 @@ public class EmotionBandResponse {
                 .songCount(emotionBand.getSongCount())
                 .commentCount(emotionBand.getCommentCount())
                 .isLiked(isLiked)
+                .songs(songs)
                 .build();
     }
 }

--- a/src/main/java/team3/kummit/service/EmotionBandService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandService.java
@@ -64,7 +64,11 @@ public class EmotionBandService {
                 .limit(3) // 최대 3개만
                 .map(band -> {
                     boolean isLiked = memberId != null && emotionBandLikeService.isLiked(band.getId(), memberId);
-                    return EmotionBandResponse.from(band, isLiked);
+                    List<SongResponse> songs = songRepository.findByEmotionBandIdOrderByCreatedAtDesc(band.getId())
+                            .stream()
+                            .map(SongResponse::from)
+                            .collect(Collectors.toList());
+                    return EmotionBandResponse.from(band, isLiked, songs);
                 })
                 .collect(Collectors.toList());
 
@@ -74,7 +78,11 @@ public class EmotionBandService {
                 .limit(10) // 최대 10개만
                 .map(band -> {
                     boolean isLiked = memberId != null && emotionBandLikeService.isLiked(band.getId(), memberId);
-                    return EmotionBandResponse.from(band, isLiked);
+                    List<SongResponse> songs = songRepository.findByEmotionBandIdOrderByCreatedAtDesc(band.getId())
+                            .stream()
+                            .map(SongResponse::from)
+                            .collect(Collectors.toList());
+                    return EmotionBandResponse.from(band, isLiked, songs);
                 })
                 .collect(Collectors.toList());
 
@@ -90,7 +98,11 @@ public class EmotionBandService {
                 .orElseThrow(() -> new ResourceNotFoundException("감정밴드를 찾을 수 없습니다."));
 
         boolean isLiked = memberId != null && emotionBandLikeService.isLiked(emotionBandId, memberId);
-        return EmotionBandResponse.from(band, isLiked);
+        List<SongResponse> songs = songRepository.findByEmotionBandIdOrderByCreatedAtDesc(emotionBandId)
+                .stream()
+                .map(SongResponse::from)
+                .collect(Collectors.toList());
+        return EmotionBandResponse.from(band, isLiked, songs);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/team3/kummit/service/EmotionBandServiceTest.java
+++ b/src/test/java/team3/kummit/service/EmotionBandServiceTest.java
@@ -1,9 +1,8 @@
 package team3.kummit.service;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,9 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import team3.kummit.domain.EmotionBand;
 import team3.kummit.domain.Member;
-import team3.kummit.domain.Song;
 import team3.kummit.dto.EmotionBandCreateRequest;
 import team3.kummit.repository.MemberRepository;
 
@@ -30,7 +27,17 @@ class EmotionBandServiceTest {
     @Test
     void testCreateEmotionBand_Success() {
         // Arrange
-        Member creator = Member.builder().id(1L).build();
+        Member creator = Member.builder()
+                .name("테스트유저")
+                .email("test@test.com")
+                .password("password123")
+                .signUpDate(LocalDate.now())
+                .bandCreateCount(0)
+                .bandJoinCount(0)
+                .likeCount(0)
+                .songAddCount(0)
+                .build();
+
         EmotionBandCreateRequest.SongDto songDto = new EmotionBandCreateRequest.SongDto();
         songDto.setTitle("Test Song");
         songDto.setArtist("Test Artist");
@@ -42,36 +49,13 @@ class EmotionBandServiceTest {
         request.setDescription("Test Description");
         request.setSong(songDto);
 
-        EmotionBand savedEmotionBand = EmotionBand.builder()
-                .id(1L)
-                .creator(creator)
-                .emotion("Happiness")
-                .description("Test Description")
-                .creatorName("Test Creator")
-                .endTime(LocalDateTime.now().plusDays(1))
-                .likeCount(0)
-                .peopleCount(0)
-                .songCount(1)
-                .commentCount(0)
-                .build();
-
-        Song savedSong = Song.builder()
-                .id(1L)
-                .creator(creator)
-                .title("Test Song")
-                .artist("Test Artist")
-                .albumImageLink("https://test.com/image.jpg")
-                .previewLink("https://test.com/preview.mp3")
-                .createdAt(LocalDateTime.now())
-                .emotionBand(savedEmotionBand)
-                .build();
         // Act
         memberRepository.save(creator);
-        Long resultId = emotionBandService.createEmotionBand(1L, request);
+        Long resultId = emotionBandService.createEmotionBand(creator.getId(), request);
 
         // Assert
         assertNotNull(resultId);
-        assertEquals(1L, resultId);
+        assertEquals(creator.getId(), resultId);
     }
 
 }


### PR DESCRIPTION
- 메인 페이지에서 각 밴드에 추가된 음악 목록을 노출하기 위해 데이터 필요
- 현재는 N+1쿼리 문제가 있어 DB부하 개선을 위해서 수정 필요