### PR TITLE
feat - 회원 로그인 기능 구현

### DIFF
--- a/src/main/java/team3/kummit/controller/EmotionBandController.java
+++ b/src/main/java/team3/kummit/controller/EmotionBandController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
-import team3.kummit.domain.Member;
 import team3.kummit.dto.EmotionBandCreateRequest;
 import team3.kummit.dto.EmotionBandCreateResponse;
 import team3.kummit.dto.EmotionBandDetailResponse;

--- a/src/main/java/team3/kummit/controller/MemberController.java
+++ b/src/main/java/team3/kummit/controller/MemberController.java
@@ -1,20 +1,21 @@
 package team3.kummit.controller;
 
-import io.swagger.v3.oas.annotations.Parameter;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import team3.kummit.domain.Member;
 import team3.kummit.dto.MemberLoginRequest;
 import team3.kummit.dto.MemberLoginResponse;
 import team3.kummit.service.MemberService;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 
 @Slf4j

--- a/src/main/java/team3/kummit/controller/MemberController.java
+++ b/src/main/java/team3/kummit/controller/MemberController.java
@@ -1,0 +1,50 @@
+package team3.kummit.controller;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team3.kummit.domain.Member;
+import team3.kummit.dto.MemberLoginRequest;
+import team3.kummit.dto.MemberLoginResponse;
+import team3.kummit.service.MemberService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+
+@Slf4j
+@RequestMapping("/api/member")
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/login")
+    @Operation(
+        summary = "회원 로그인",
+        description = "가입된 이메일과 비밀번호로 로그인을 시도합니다.",
+        tags = {"Member"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "401", description = "로그인 실패: 인증되지 않음")
+    })
+    public ResponseEntity<MemberLoginResponse> memberLogin(
+            @Parameter(description = "로그인 요청 데이터 (이메일과 비밀번호 포함)")
+            @RequestBody MemberLoginRequest memberLoginRequest) {
+        Member member = memberService.findByEmail(memberLoginRequest.email());
+        if(member == null){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if(!member.getPassword().equals(memberLoginRequest.password())){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        return ResponseEntity.ok(new MemberLoginResponse(member.getId()));
+    }
+}

--- a/src/main/java/team3/kummit/dto/MemberLoginRequest.java
+++ b/src/main/java/team3/kummit/dto/MemberLoginRequest.java
@@ -1,0 +1,4 @@
+package team3.kummit.dto;
+
+public record MemberLoginRequest (String email, String password){
+}

--- a/src/main/java/team3/kummit/dto/MemberLoginResponse.java
+++ b/src/main/java/team3/kummit/dto/MemberLoginResponse.java
@@ -1,0 +1,4 @@
+package team3.kummit.dto;
+
+public record MemberLoginResponse (Long memberId){
+}

--- a/src/main/java/team3/kummit/repository/MemberRepository.java
+++ b/src/main/java/team3/kummit/repository/MemberRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team3.kummit.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    public Member findByEmail(String email);
 }

--- a/src/main/java/team3/kummit/service/MemberService.java
+++ b/src/main/java/team3/kummit/service/MemberService.java
@@ -16,4 +16,9 @@ public class MemberService {
         return memberRepository.findById(memberId).orElseThrow(()-> new IllegalArgumentException("Not existing Member id"));
     }
 
+    public Member findByEmail(String email){
+        return memberRepository.findByEmail(email);
+    }
+
+
 }


### PR DESCRIPTION
- 회원 로그인 기능 구현 

### Request

`POST /api/member`

### Response

```
{
  "email": "이메일",
  "password": "비밀번호"
}
```

```
{
  "memberId": 1
}
```