### PR TITLE
fix: 마이페이지 밴드 리스트가 같은 응답을 내리는 문제

### DIFF
--- a/src/main/java/team3/kummit/repository/EmotionBandArchiveRepository.java
+++ b/src/main/java/team3/kummit/repository/EmotionBandArchiveRepository.java
@@ -5,12 +5,17 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import team3.kummit.domain.EmotionBandArchive;
 
 public interface EmotionBandArchiveRepository extends JpaRepository<EmotionBandArchive, Long> {
     Optional<EmotionBandArchive> findByCreatorIdAndEmotionBandId(Long memberId, Long emotionBandId);
     boolean existsByCreatorIdAndEmotionBandId(Long memberId, Long emotionBandId);
+
+    // 사용자가 보관한 밴드 ID 목록 조회
+    @Query("SELECT eba.emotionBand.id FROM EmotionBandArchive eba WHERE eba.creator.id = :memberId")
+    List<Long> findEmotionBandIdListByMemberId(@Param("memberId") Long memberId);
 
     @Query("SELECT eb.id FROM EmotionBand eb where eb.creator.id =:memberId")
     List<Long> findEmotionBandIdListByCreator(Long memberId);

--- a/src/main/java/team3/kummit/repository/EmotionBandLikeRepository.java
+++ b/src/main/java/team3/kummit/repository/EmotionBandLikeRepository.java
@@ -5,12 +5,17 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import team3.kummit.domain.EmotionBandLike;
 
 public interface EmotionBandLikeRepository extends JpaRepository<EmotionBandLike, Long> {
     Optional<EmotionBandLike> findByCreatorIdAndEmotionBandId(Long memberId, Long emotionBandId);
     Long countByEmotionBandId(Long emotionBandId);
+
+    // 사용자가 공감한 밴드 ID 목록 조회
+    @Query("SELECT ebl.emotionBand.id FROM EmotionBandLike ebl WHERE ebl.creator.id = :memberId")
+    List<Long> findEmotionBandIdListByMemberId(@Param("memberId") Long memberId);
 
     @Query("SELECT eb.id FROM EmotionBand eb where eb.creator.id =:memberId")
     List<Long> findEmotionBandIdListByCreator(Long memberId);

--- a/src/main/java/team3/kummit/service/EmotionBandArchiveService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandArchiveService.java
@@ -87,6 +87,6 @@ public class EmotionBandArchiveService {
     }
 
     public List<Long> findEmotionBandIdListByCreator(Long memberId){
-        return archiveRepository.findEmotionBandIdListByCreator(memberId);
+        return archiveRepository.findEmotionBandIdListByMemberId(memberId);
     }
 }

--- a/src/main/java/team3/kummit/service/EmotionBandLikeService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandLikeService.java
@@ -96,6 +96,6 @@ public class EmotionBandLikeService {
     }
 
     public List<Long> findEmotionBandListByMemberId(Long memberId) {
-        return bandRepository.findEmotionBandIdListByCreator(memberId);
+        return likeRepository.findEmotionBandIdListByMemberId(memberId);
     }
 }


### PR DESCRIPTION
- 공감한 밴드는 EmotionBandLike 테이블에서 사용자가 좋아요한 밴드 ID 목록을 반환해야 한다
- 보관한 밴드는 EmotionBandArchive 테이블에서 사용자가 보관한 밴드 ID 목록을 반환해야 한다
- 현재는 사용자가 생성한 밴드를 찾는 쿼리를 사용하고 있음
- 리포지토리에 각 쿼리를 추가하고 이를 사용하도록 수정하자