### PR TITLE
feat: API 실행과정을 트레이싱하기 위한 스프링 인터셉터 추가

### DIFF
--- a/src/main/java/team3/kummit/config/InterceptorConfig.java
+++ b/src/main/java/team3/kummit/config/InterceptorConfig.java
@@ -1,0 +1,19 @@
+package team3.kummit.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import team3.kummit.interceptor.LogInterceptor;
+
+@Configuration
+public class InterceptorConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LogInterceptor())
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "/*.ico", "/error");
+    }
+}

--- a/src/main/java/team3/kummit/interceptor/LogInterceptor.java
+++ b/src/main/java/team3/kummit/interceptor/LogInterceptor.java
@@ -24,6 +24,7 @@ public class LogInterceptor implements HandlerInterceptor {
 
         request.setAttribute(LOG_ID, logId);
         request.setAttribute(START_TIME, System.currentTimeMillis());
+        request.setAttribute(MEMBER_ID, memberId);
 
         if (handler instanceof HandlerMethod handlerMethod) {
             log.info("REQUEST [{}][{}][{}] from memberId = {}", logId, requestURI, handlerMethod.getMethod().getName(), memberId);
@@ -36,10 +37,11 @@ public class LogInterceptor implements HandlerInterceptor {
                                 Object handler, Exception ex) {
         String requestURI = request.getRequestURI();
         String logId = (String) request.getAttribute(LOG_ID);
+        String memberId = (String) request.getAttribute(MEMBER_ID);
         Long startTime = (Long) request.getAttribute(START_TIME);
         long duration = System.currentTimeMillis() - startTime;
 
-        log.info("RESPONSE [{}][{}][{}ms]", logId, requestURI, duration);
+        log.info("RESPONSE [{}][{}][{}ms] from memberId = {}", logId, requestURI, duration, memberId);
 
         if (ex != null) {
             log.error("EXCEPTION [{}][{}]", logId, requestURI, ex);

--- a/src/main/java/team3/kummit/interceptor/LogInterceptor.java
+++ b/src/main/java/team3/kummit/interceptor/LogInterceptor.java
@@ -1,0 +1,49 @@
+package team3.kummit.interceptor;
+
+import java.util.UUID;
+
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LogInterceptor implements HandlerInterceptor {
+
+    private static final String LOG_ID = "logId";
+    private static final String START_TIME = "startTime";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String requestURI = request.getRequestURI();
+        String logId = UUID.randomUUID().toString();
+
+        request.setAttribute(LOG_ID, logId);
+        request.setAttribute(START_TIME, System.currentTimeMillis());
+
+        if (handler instanceof HandlerMethod handlerMethod) {
+            log.info("REQUEST [{}][{}][{}]", logId, requestURI, handlerMethod.getMethod().getName());
+        } else {
+            log.info("REQUEST [{}][{}][{}]", logId, requestURI, handler);
+        }
+
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+        String requestURI = request.getRequestURI();
+        String logId = (String) request.getAttribute(LOG_ID);
+        Long startTime = (Long) request.getAttribute(START_TIME);
+        long duration = System.currentTimeMillis() - startTime;
+
+        log.info("RESPONSE [{}][{}][{}ms]", logId, requestURI, duration);
+
+        if (ex != null) {
+            log.error("EXCEPTION [{}][{}]", logId, requestURI, ex);
+        }
+    }
+}

--- a/src/main/java/team3/kummit/interceptor/LogInterceptor.java
+++ b/src/main/java/team3/kummit/interceptor/LogInterceptor.java
@@ -14,21 +14,20 @@ public class LogInterceptor implements HandlerInterceptor {
 
     private static final String LOG_ID = "logId";
     private static final String START_TIME = "startTime";
+    private static final String MEMBER_ID = "memberId";
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String requestURI = request.getRequestURI();
         String logId = UUID.randomUUID().toString();
+        String memberId = request.getParameter(MEMBER_ID) == null ? "0" : request.getParameter(MEMBER_ID);
 
         request.setAttribute(LOG_ID, logId);
         request.setAttribute(START_TIME, System.currentTimeMillis());
 
         if (handler instanceof HandlerMethod handlerMethod) {
-            log.info("REQUEST [{}][{}][{}]", logId, requestURI, handlerMethod.getMethod().getName());
-        } else {
-            log.info("REQUEST [{}][{}][{}]", logId, requestURI, handler);
+            log.info("REQUEST [{}][{}][{}] from memberId = {}", logId, requestURI, handlerMethod.getMethod().getName(), memberId);
         }
-
         return true;
     }
 

--- a/src/main/java/team3/kummit/service/CommentService.java
+++ b/src/main/java/team3/kummit/service/CommentService.java
@@ -12,8 +12,6 @@ import team3.kummit.api.CommentResponse;
 import team3.kummit.domain.Comment;
 import team3.kummit.domain.EmotionBand;
 import team3.kummit.domain.Member;
-import team3.kummit.api.CommentRequest;
-import team3.kummit.api.CommentResponse;
 import team3.kummit.repository.CommentRepository;
 import team3.kummit.repository.EmotionBandRepository;
 import team3.kummit.repository.MemberRepository;

--- a/src/test/java/team3/kummit/service/comment/CommentCreateServiceTest.java
+++ b/src/test/java/team3/kummit/service/comment/CommentCreateServiceTest.java
@@ -19,10 +19,6 @@ import team3.kummit.api.CommentResponse;
 import team3.kummit.domain.Comment;
 import team3.kummit.domain.EmotionBand;
 import team3.kummit.domain.Member;
-
-import team3.kummit.api.CommentRequest;
-import team3.kummit.api.CommentResponse;
-
 import team3.kummit.repository.CommentRepository;
 import team3.kummit.repository.EmotionBandRepository;
 import team3.kummit.repository.MemberRepository;


### PR DESCRIPTION

API 요청에 UUID를 부여하고, 요청을 응답하는데 걸리는 시간을 로그로 남기는 간단한 스프링 인터셉터를 추가해보았습니다.