### PR TITLE
refactor: `EmotionBrandLikeService`

### DIFF
--- a/src/main/java/team3/kummit/repository/EmotionBandRepository.java
+++ b/src/main/java/team3/kummit/repository/EmotionBandRepository.java
@@ -4,7 +4,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import team3.kummit.domain.EmotionBand;
 
@@ -25,5 +28,14 @@ public interface EmotionBandRepository extends JpaRepository<EmotionBand, Long> 
             "WHERE eb.endTime > :currentTime and eb.id in :emotionBandIdList")
     List<EmotionBand> findAllByEmotionBandIdListWithSongs(List<Long> emotionBandIdList, LocalDateTime currentTime);
 
+    @Modifying
+    @Transactional
+    @Query("update EmotionBand e set e.likeCount = e.likeCount + 1 where e.id = :emotionBandId")
+    int incrementLikeCount(@Param("emotionBandId") Long emotionBandId);
+
+    @Modifying
+    @Transactional
+    @Query("update EmotionBand e set e.likeCount = e.likeCount - 1 where e.id = :emotionBandId")
+    int decrementLikeCount(@Param("emotionBandId") Long emotionBandId);
 
 }

--- a/src/main/java/team3/kummit/repository/MemberRepository.java
+++ b/src/main/java/team3/kummit/repository/MemberRepository.java
@@ -3,10 +3,24 @@ package team3.kummit.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import team3.kummit.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByName(String name);
+
+    @Modifying
+    @Transactional
+    @Query("update Member m set m.likeCount = m.likeCount + 1 where m.id = :memberId")
+    int incrementLikeCount(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Transactional
+    @Query("update Member m set m.likeCount = m.likeCount - 1 where m.id = :memberId")
+    int decrementLikeCount(@Param("memberId") Long memberId);
 }

--- a/src/main/java/team3/kummit/service/EmotionBandLikeService.java
+++ b/src/main/java/team3/kummit/service/EmotionBandLikeService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team3.kummit.domain.*;
-import team3.kummit.exception.ResourceNotFoundException;
 import team3.kummit.repository.EmotionBandLikeRepository;
 import team3.kummit.repository.EmotionBandRepository;
 import team3.kummit.repository.MemberRepository;
@@ -18,42 +17,21 @@ public class EmotionBandLikeService {
     private final EmotionBandLikeRepository likeRepository;
     private final EmotionBandRepository bandRepository;
     private final MemberRepository memberRepository;
+    private final EntityValidator entityValidator;
 
     @Transactional
     public boolean toggleLike(Long emotionBandId, Long memberId) {
-        EmotionBand band = bandRepository.findById(emotionBandId)
-                .orElseThrow(() -> new ResourceNotFoundException("감정밴드를 찾을 수 없습니다."));
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+        EmotionBand band = bandRepository.findById(emotionBandId).orElse(null);
+        Member member = memberRepository.findById(memberId).orElse(null);
+
+        entityValidator.validateActiveEmotionBand(band);
+        entityValidator.validateMember(member);
 
         return likeRepository.findByCreatorIdAndEmotionBandId(memberId, emotionBandId)
                 .map(like -> {
                     likeRepository.delete(like);
-
-                    // likeCount 감소
-                    Integer currentBandLikeCount = band.getLikeCount() != null ? band.getLikeCount() : 0;
-                    Integer currentMemberLikeCount = member.getLikeCount() != null ? member.getLikeCount() : 0;
-
-                    EmotionBand updatedBand = band.toBuilder()
-                            .id(band.getId())
-                            .creator(band.getCreator())
-                            .creatorName(band.getCreatorName())
-                            .emotion(band.getEmotion())
-                            .description(band.getDescription())
-                            .endTime(band.getEndTime())
-                            .likeCount(Math.max(0, currentBandLikeCount - 1))
-                            .peopleCount(band.getPeopleCount())
-                            .songCount(band.getSongCount())
-                            .commentCount(band.getCommentCount())
-                            .build();
-
-                    Member updatedMember = member.toBuilder()
-                            .likeCount(Math.max(0, currentMemberLikeCount - 1))
-                            .build();
-
-                    bandRepository.save(updatedBand);
-                    memberRepository.save(updatedMember);
-
+                    bandRepository.decrementLikeCount(emotionBandId);
+                    memberRepository.decrementLikeCount(memberId);
                     return false;
                 })
                 .orElseGet(() -> {
@@ -61,31 +39,8 @@ public class EmotionBandLikeService {
                             .creator(member)
                             .emotionBand(band)
                             .build());
-
-                    // likeCount 증가
-                    Integer currentBandLikeCount = band.getLikeCount() != null ? band.getLikeCount() : 0;
-                    Integer currentMemberLikeCount = member.getLikeCount() != null ? member.getLikeCount() : 0;
-
-                    EmotionBand updatedBand = band.toBuilder()
-                            .id(band.getId())
-                            .creator(band.getCreator())
-                            .creatorName(band.getCreatorName())
-                            .emotion(band.getEmotion())
-                            .description(band.getDescription())
-                            .endTime(band.getEndTime())
-                            .likeCount(currentBandLikeCount + 1)
-                            .peopleCount(band.getPeopleCount())
-                            .songCount(band.getSongCount())
-                            .commentCount(band.getCommentCount())
-                            .build();
-
-                    Member updatedMember = member.toBuilder()
-                            .likeCount(currentMemberLikeCount + 1)
-                            .build();
-
-                    bandRepository.save(updatedBand);
-                    memberRepository.save(updatedMember);
-
+                    bandRepository.incrementLikeCount(emotionBandId);
+                    memberRepository.incrementLikeCount(memberId);
                     return true;
                 });
     }

--- a/src/test/java/team3/kummit/service/EmotionBandLikeServiceTest.java
+++ b/src/test/java/team3/kummit/service/EmotionBandLikeServiceTest.java
@@ -1,8 +1,8 @@
 package team3.kummit.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import team3.kummit.domain.EmotionBand;
 import team3.kummit.domain.EmotionBandLike;
 import team3.kummit.domain.Member;
-import team3.kummit.exception.ResourceNotFoundException;
 import team3.kummit.repository.EmotionBandLikeRepository;
 import team3.kummit.repository.EmotionBandRepository;
 import team3.kummit.repository.MemberRepository;
@@ -37,6 +36,9 @@ class EmotionBandLikeServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
+    @Mock
+    private EntityValidator entityValidator;
+
     @InjectMocks
     private EmotionBandLikeService emotionBandLikeService;
 
@@ -50,6 +52,7 @@ class EmotionBandLikeServiceTest {
                 .id(1L)
                 .name("테스트유저")
                 .email("test@test.com")
+                .likeCount(0)
                 .build();
 
         testEmotionBand = EmotionBand.builder()
@@ -59,7 +62,7 @@ class EmotionBandLikeServiceTest {
                 .emotion("기쁨")
                 .description("테스트 감정밴드")
                 .endTime(LocalDateTime.now().plusDays(1))
-                .likeCount(5)
+                .likeCount(0)
                 .peopleCount(3)
                 .songCount(2)
                 .commentCount(3)
@@ -86,17 +89,15 @@ class EmotionBandLikeServiceTest {
                 .thenReturn(Optional.empty());
         when(likeRepository.save(any(EmotionBandLike.class)))
                 .thenReturn(testLike);
-        when(bandRepository.save(any(EmotionBand.class)))
-                .thenReturn(testEmotionBand.toBuilder().likeCount(6).build());
-        when(memberRepository.save(any(Member.class)))
-                .thenReturn(testMember.toBuilder().likeCount(11).build());
+        doNothing().when(entityValidator).validateMember(any());
+        doNothing().when(entityValidator).validateActiveEmotionBand(any());
 
         boolean result = emotionBandLikeService.toggleLike(emotionBandId, memberId);
 
         assertThat(result).isTrue();
         verify(likeRepository).save(any(EmotionBandLike.class));
-        verify(bandRepository).save(any(EmotionBand.class));
-        verify(memberRepository).save(any(Member.class));
+        verify(bandRepository).incrementLikeCount(emotionBandId);
+        verify(memberRepository).incrementLikeCount(memberId);
     }
 
     @Test
@@ -111,47 +112,15 @@ class EmotionBandLikeServiceTest {
                 .thenReturn(Optional.of(testMember));
         when(likeRepository.findByCreatorIdAndEmotionBandId(memberId, emotionBandId))
                 .thenReturn(Optional.of(testLike));
-        when(bandRepository.save(any(EmotionBand.class)))
-                .thenReturn(testEmotionBand.toBuilder().likeCount(4).build());
-        when(memberRepository.save(any(Member.class)))
-                .thenReturn(testMember.toBuilder().likeCount(9).build());
+        doNothing().when(entityValidator).validateMember(any());
+        doNothing().when(entityValidator).validateActiveEmotionBand(any());
 
         boolean result = emotionBandLikeService.toggleLike(emotionBandId, memberId);
 
         assertThat(result).isFalse();
         verify(likeRepository).delete(testLike);
-        verify(bandRepository).save(any(EmotionBand.class));
-        verify(memberRepository).save(any(Member.class));
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 감정밴드에 좋아요 시 예외 발생")
-    void toggleLike_EmotionBandNotFound_ThrowsException() {
-        Long emotionBandId = 999L;
-        Long memberId = 1L;
-
-        when(bandRepository.findById(emotionBandId))
-                .thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> emotionBandLikeService.toggleLike(emotionBandId, memberId))
-                .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("감정밴드를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 사용자로 좋아요 시 예외 발생")
-    void toggleLike_MemberNotFound_ThrowsException() {
-        Long emotionBandId = 1L;
-        Long memberId = 999L;
-
-        when(bandRepository.findById(emotionBandId))
-                .thenReturn(Optional.of(testEmotionBand));
-        when(memberRepository.findById(memberId))
-                .thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> emotionBandLikeService.toggleLike(emotionBandId, memberId))
-                .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("사용자를 찾을 수 없습니다.");
+        verify(bandRepository).decrementLikeCount(emotionBandId);
+        verify(memberRepository).decrementLikeCount(memberId);
     }
 
     @Test


### PR DESCRIPTION
- EntityValidator을 통한 유효성 검증 추가
- 트랜잭션 내에서 발생할 수 있는 race condition이 있음
  - JPA에서 단일 쿼리로 수행하도록 변경
- 테스트 케이스 수정
  - JPA 메소드 호출을 확인하도록 변경
  - EntityValidator에게 유효성 검증을 위임함에 따라 서비스의 테스트에서는 테스트를 수행하지 않음